### PR TITLE
Copy LICENSE file to /licenses

### DIFF
--- a/Containerfile.thanos
+++ b/Containerfile.thanos
@@ -21,6 +21,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 
 COPY --from=builder /go/bin/thanos /bin/thanos
+COPY --from=builder /workspace/LICENSE /licenses/.
 
 USER nobody
 ENTRYPOINT [ "/bin/thanos" ]


### PR DESCRIPTION
This commit adds the LICENSE file to the /licenses directory in the container image which is expected by Konflux.